### PR TITLE
Fix hazelcast-platform-operator-wan-sync.adoc formatting

### DIFF
--- a/docs/modules/ROOT/pages/hazelcast-platform-operator-wan-sync.adoc
+++ b/docs/modules/ROOT/pages/hazelcast-platform-operator-wan-sync.adoc
@@ -553,4 +553,3 @@ kubectl delete $(kubectl get wansync,wanreplications,map,hazelcast -o name)
 
 - xref:operator:ROOT:wan-replication.adoc[]
 - xref:hazelcast-platform-operator-expose-externally.adoc[]
------


### PR DESCRIPTION
Fixes the following warning

```
11:42:15 AM: [08:42:15.887] WARN (asciidoctor): unterminated listing block
11:42:15 AM:     file: docs/modules/ROOT/pages/hazelcast-platform-operator-wan-sync.adoc:556
11:42:15 AM:     source: https://github.com/hazelcast-guides/hazelcast-platform-operator-wan-sync (branch: master | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66dabf7a408ba700081a10fa#L131